### PR TITLE
Pending step snippets should have callback with arguments

### DIFF
--- a/templates/bootstrap/features.tmpl
+++ b/templates/bootstrap/features.tmpl
@@ -97,7 +97,8 @@
                       <% if(step.result.status === 'undefined') { %>
                         <pre class=info>
 this.Then(/^<%= step.name.replace(/"[^"]*"/g, '"\(\[\^\"\]\*\)"') %>$/, function(<% for (var i=1; i<(step.name.split('"').length / 2); i++) { %>arg<%= i %>, <% } %>callback) {
-  callback.pending();
+  // Write code here that turns the phrase above into concrete actions
+  callback(null, 'pending');
 });
                         </pre>
                       <% } %>


### PR DESCRIPTION
The module currently reports  `callback.pending();` when steps are missing. It should report

```
  // Write code here that turns the phrase above into concrete actions
  callback(null, 'pending');
```
