### PR TITLE
Fix Foundation template for local

### DIFF
--- a/templates/foundation/index.tmpl
+++ b/templates/foundation/index.tmpl
@@ -2,8 +2,8 @@
 <html>
   <head>
     <title>Cucumber Feature Report</title>
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/normalize/3.0.1/normalize.min.css">
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/foundation/4.3.2/css/foundation.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.1/normalize.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/foundation/4.3.2/css/foundation.min.css">
     <style type="text/css">
       <%= styles %>
     </style>
@@ -26,9 +26,9 @@
 
     <%= features %>
 
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/foundation/5.2.2/js/foundation.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.5.1/moment.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/foundation/5.2.2/js/foundation.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.5.1/moment.min.js"></script>
     <script>
       <%= script %>
     </script>


### PR DESCRIPTION
When I try to load the template in my local file system, it does not load the resources that starts with "//". Adding "https://" solved this problem.

Attached screenshot of the problem.

![capture](https://cloud.githubusercontent.com/assets/436978/18818056/da8d22ea-836f-11e6-9d92-1cf261dcb54d.PNG)
