### PR TITLE
Show hidden hooks if they fail

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -103,7 +103,7 @@ var generateReport = function(options) {
                         });
                     }
 
-                    if (!step.result || step.hidden) {
+                    if (!step.result) {
                         return 0;
                     }
                     if (step.result.status === result.status.passed) {

--- a/templates/bootstrap/features.tmpl
+++ b/templates/bootstrap/features.tmpl
@@ -44,7 +44,7 @@
               <div id="collapseScenario<%= featureIndex %>_<%= scenarioIndex %>" class="panel-collapse collapse">
                 <div class="panel-body">
                   <% _.each(element.steps, function(step, stepIndex) { %>
-                    <% if(!step.hidden || step.image || step.text) { %>
+                    <% if(!step.hidden || step.image || step.text || step.result.status === 'failed') { %>
                     <p class="scenario-container">
                     <% if(step.result) { %>
                       <% if(step.result.status === 'passed') { %>


### PR DESCRIPTION
**Issue:**
 If scenario fails in Before/After hooks, the report does not show the hooks since they are hidden with no attachments but there is a stack trace in JSON which should be displayed in the report. Also, the overall results shows SKIPPED instead of FAILURES, and report does not update the failure counts.


_This PR Fixes_

- If scenario fails in hidden hooks (before/after), show them to report with stack trace.
- Report overall results as FAIL if scenario failed in hidden hooks instead of SKIPPED, and update the failure counts as the scenarios failed but not skipped.
- It won't show hidden hooks if there is not info attached or not failed.

