### PR TITLE
Option to store screenshot if required

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ Custom project name. If not passed, module reads the name from projects package.
  
 #### `storeScreenShots`
 Type: `Boolean`
-Default: `false`
+Default: `undefined`
 
 `true`: Stores all screenShots stores the screenShots to the default directory. It creates a directory 'screehshot' if does not exists.
-`false`: Does not store screenShots but attaches screenShots as a inline images to Steps on HTML report
+`false` or `undefined` : Does not store screenShots but attaches screenShots as a step-inline images to HTML report
 
 
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ Type: `String` (optional)
 
 Custom project name. If not passed, module reads the name from projects package.json which is preferable.
  
+#### `storeScreenShots`
+Type: `Boolean`
+Default: `false`
+
+`true`: Stores all screenShots stores the screenShots to the default directory. It creates a directory 'screehshot' if does not exists.
+`false`: Does not store screenShots but attaches screenShots as a inline images to Steps on HTML report
+
+
 
 ## Tips
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -112,9 +112,7 @@ var generateReport = function(options) {
                                 } else {
                                     step.text = step.text.concat('<br>' + Base64.decode(embedding.data));
                                 }
-                            } else if (embedding.mime_type === 'image/png') {
-                              step.image = 'data:image/png;base64,' + embedding.data
-                            } else {
+                            } else if(options.storeScreenShots && options.storeScreenShots === true) {
                                 var name = step.name && step.name.split(' ').join('_') || step.keyword.trim();
                                 if (!fs.existsSync(screenShotDirectory)) {
                                     fs.mkdirSync(screenShotDirectory);
@@ -123,6 +121,8 @@ var generateReport = function(options) {
                                 var filename = path.join(screenShotDirectory, name);
                                 fs.writeFileSync(filename, embedding.data, 'base64');
                                 step.image = 'screenshot/' + name;
+                            } else if(embedding.mime_type === 'image/png') {
+                              step.image = 'data:image/png;base64,' + embedding.data
                             }
                         });
                     }


### PR DESCRIPTION
* Adds an option to Store Screenshot to the default `screenshot` directory

#### `storeScreenShots`
Type: `Boolean`
Default: `undefined`

`true`: Stores all screenShots stores the screenShots to the default directory. It creates a directory 'screehshot' if does not exists.
`false` or `undefined` : Does not store screenShots but attaches screenShots as a step-inline images to HTML report

