### PR TITLE
Fix Reporter & Slice the scenario chart

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -138,30 +138,27 @@ var generateReport = function(options) {
                     if (!step.result) {
                         return 0;
                     }
-                    if (!step.hidden) {
 
-                        if (step.result.duration) {
-                            element.time += step.result.duration;
-                        }
-                        if (step.result.status === result.status.passed) {
-                            return element.passed++;
-                        }
-                        if (step.result.status === result.status.failed) {
-                            return element.failed++;
-                        }
-                        if (step.result.status === result.status.undefined) {
-                            return element.notdefined++;
-                        }
-                        if (step.result.status === result.status.pending) {
-                            return element.pending++;
-                        }
-                        if (step.result.status === result.status.ambiguous) {
-                            return element.ambiguous++;
-                        }
+                    if (step.result.duration) element.time += step.result.duration;
 
-                        element.skipped++;
+                    if (step.result.status === result.status.passed) {
+                        return element.passed++;
                     }
-                });                
+                    if (step.result.status === result.status.failed) {
+                        return element.failed++;
+                    }
+                    if (step.result.status === result.status.undefined) {
+                        return element.notdefined++;
+                    }
+                    if (step.result.status === result.status.pending) {
+                        return element.pending++;
+                    }
+                    if (step.result.status === result.status.ambiguous) {
+                        return element.ambiguous++;
+                    }
+
+                    element.skipped++;
+                });
 
                 if (element.time > 0) {
                     feature.time += element.time;

--- a/templates/bootstrap/piechart.js
+++ b/templates/bootstrap/piechart.js
@@ -30,7 +30,9 @@ function drawChart(chartData) {
             1: {offset: 0.4},
             2: {offset: 0.4},
             3: {offset: 0.4},
-            4: {offset: 0.4}
+            4: {offset: 0.4},
+            5: {offset: 0.4},
+            6: {offset: 0.4}
         },
         titleTextStyle: {
             fontSize: '13',


### PR DESCRIPTION
### Issue
When scenario fails in `@Before` hooks, the current version shows it's pending instead of FAIL. Report should FAIL if there are any failures in Before/After hook,

<img width="1200" alt="screen shot 2016-12-05 at 12 29 23 pm" src="https://cloud.githubusercontent.com/assets/3663389/20895415/5db59da6-bae7-11e6-993c-e9d59dc74755.png">




### Fix

<img width="1194" alt="screen shot 2016-12-05 at 12 30 11 pm" src="https://cloud.githubusercontent.com/assets/3663389/20895426/65c4f8de-bae7-11e6-856c-be916b2e7f4f.png">
