### PR TITLE
Define function to santize filenames

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -114,6 +114,15 @@ var generateReport = function(options) {
                     if (step.embeddings !== undefined) {
                         var Base64 = require('js-base64').Base64;
                         step.embeddings.forEach(function(embedding) {
+
+                            var sanitizeFileName = function(name) {
+                                var unsafeCharacters = /[\/\\\|:"\*\?<>]/g;
+                                name = name.trim();
+                                name = name.replace(unsafeCharacters, ' ');
+                                name = name.split(' ').join('_');
+                                return name;
+                            };
+
                             if (embedding.mime_type === 'text/plain') {
                                 if (!step.text) {
                                     step.text = Base64.decode(embedding.data);
@@ -121,7 +130,7 @@ var generateReport = function(options) {
                                     step.text = step.text.concat('<br>' + Base64.decode(embedding.data));
                                 }
                             } else if (options.storeScreenShots && options.storeScreenShots === true) {
-                                var name = step.name && step.name.split(' ').join('_') || step.keyword.trim();
+                                var name = sanitizeFileName(step.name || step.keyword);
                                 if (!fs.existsSync(screenShotDirectory)) {
                                     fs.mkdirSync(screenShotDirectory);
                                 }


### PR DESCRIPTION
Proposed fix for https://github.com/gkushang/cucumber-html-reporter/issues/45.

Replace characters which aren't OS-friendly with `_`s. 