### PR TITLE
make chai a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   "license": "MIT",
   "homepage": "https://github.com/gkushang/cucumber-html-reporter#readme",
   "dependencies": {
-    "chai": "^3.5.0",
     "find": "^0.2.7",
     "js-base64": "^2.1.9",
     "jsonfile": "^2.3.1",
@@ -65,6 +64,7 @@
     "open": "0.0.5"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
     "cucumber": "^1.3.1"
   }
 }


### PR DESCRIPTION
At the moment chai is listed as a dependency.
It is clearly a dev dependency 👍 