### PR TITLE
Bootstrap template fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Attach JSON to HTML report
 
 ```
 
-## Changelog
+## Changelog 
 
 [changelog][9]
 

--- a/templates/bootstrap/features.tmpl
+++ b/templates/bootstrap/features.tmpl
@@ -134,7 +134,7 @@ this.Then(/^<%= step.name.replace(/"[^"]*"/g, '"\(\[\^\"\]\*\)"') %>$/, function
                       <% } %>
 
                        <% if (step.image) { %>
-                                                <a class="toggle" href="#">Screenshot -</a>
+                                                <a class="toggle" href="javascript: void(0);">Screenshot -</a>
                                                 <a class="screenshot" href="<%= step.image %>">
                                                  <img class="screenshot" style="height:100%;width:100%" id="my_images" src="<%= step.image %>"/>
                                                  </a>

--- a/templates/bootstrap/features.tmpl
+++ b/templates/bootstrap/features.tmpl
@@ -136,7 +136,7 @@ this.Then(/^<%= step.name.replace(/"[^"]*"/g, '"\(\[\^\"\]\*\)"') %>$/, function
                        <% if (step.image) { %>
                                                 <a class="toggle" href="javascript: void(0);">Screenshot -</a>
                                                 <a class="screenshot" href="<%= step.image %>">
-                                                 <img class="screenshot" style="height:100%;width:100%" id="my_images" src="<%= step.image %>"/>
+                                                 <img class="screenshot" style="height:100%;width:100%;display:none;" id="my_images" src="<%= step.image %>"/>
                                                  </a>
                        <% } %>
 

--- a/templates/bootstrap/features.tmpl
+++ b/templates/bootstrap/features.tmpl
@@ -134,7 +134,7 @@ this.Then(/^<%= step.name.replace(/"[^"]*"/g, '"\(\[\^\"\]\*\)"') %>$/, function
                       <% } %>
 
                        <% if (step.image) { %>
-                                                <a class="toggle" href="javascript: void(0);">Screenshot -</a>
+                                                <a class="toggle" href="javascript: void(0);">Screenshot +</a>
                                                 <a class="screenshot" href="<%= step.image %>">
                                                  <img class="screenshot" style="height:100%;width:100%;display:none;" id="my_images" src="<%= step.image %>"/>
                                                  </a>

--- a/templates/bootstrap/script.js
+++ b/templates/bootstrap/script.js
@@ -10,10 +10,10 @@ $(document).ready(function() {
     $('a.toggle').on('click', function() {
         if ($(this).text() === 'Screenshot -') {
             $(this).text('Screenshot +');
-            $(this).siblings('a.screenshot').find('img').hide();
+            $(this).next('a.screenshot').find('img').hide();
         } else {
             $(this).text('Screenshot -');
-            $(this).siblings('a.screenshot').find('img').show();
+            $(this).next('a.screenshot').find('img').show();
         }
     });
     var $generated = $('.generated-on');


### PR DESCRIPTION
# Fixes for BOOTSTRAP template 

- Removed unexpected reports scrolling during expanding screenshots
- Made all screenshots collapsed by default. It prevents browser freezes for reports with a big number of screenshots
- Fix for reports with screenshots for each step. Now only one screenshot is expanded when we click on "Screenshot +" link. In previous variant more then one screenshot could be expanded by one click