### PR TITLE
Counting After Hooks as Steps (fix for issue #63)

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -143,7 +143,7 @@ var generateReport = function(options) {
                         });
                     }
 
-                    if (!step.result) {
+                    if (!step.result || (step.hidden && !step.text && !step.image)) {
                         return 0;
                     }
 


### PR DESCRIPTION
fix for https://github.com/gkushang/cucumber-html-reporter/issues/63

* Do not count `hidden` Before/After hooks if they are not displayed on the report

<img width="584" alt="screen shot 2017-04-26 at 11 49 29 am" src="https://cloud.githubusercontent.com/assets/3663389/25443660/72743a28-2a76-11e7-8d9a-4ef2447b57ab.png">
