### PR TITLE
Added support for JSON attachments

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -214,6 +214,14 @@ var generateReport = function (options) {
                                 } else {
                                     step.text = step.text.concat('<br>' + embedding.data);
                                 }
+                            } else if (embedding.mime_type === 'application/json') {
+                                var decoded = new Buffer(embedding.data, 'base64').toString('ascii');
+
+                                if (!step.text) {
+                                    step.text = decoded;
+                                } else {
+                                    step.text = step.text.concat('<br>' + decoded);
+                                }
                             } else if (options.storeScreenShots && options.storeScreenShots === true) {
                                 var name = sanitizeFileName(step.name || step.keyword);
                                 if (!fs.existsSync(screenShotDirectory)) {

--- a/test/features/step_definitions/stepDefs.js
+++ b/test/features/step_definitions/stepDefs.js
@@ -39,6 +39,12 @@ defineSupportCode(function({Given, Then, When}) {
         callback();
     });
 
+    Then(/^a failing scenario captures a json payload/, function (callback) {
+        var jsonData = new Buffer(JSON.stringify({ key: 'value' })).toString('base64');
+        this.attach(new Buffer(jsonData, 'base64'), 'application/json');
+        callback();
+    });
+
     Then(/^he throws the pending exception from this step$/, function (callback) {
         callback(null, 'pending');
     });

--- a/test/features/unhappy/unhappy.feature
+++ b/test/features/unhappy/unhappy.feature
@@ -6,6 +6,7 @@ Feature: Unhappy HTML reporting
     Given Fred runs a failing cucumber scenario
     When he provides cucumber JSON file to reporter
     And a failing scenario captures a screenshot
+    And a failing scenario captures a json payload
     Then cucumber-html-reporter should create HTML report with Screenshot
 
   @pendingStep


### PR DESCRIPTION
Based on MIME type of the attachment.

Payload is expected to be base64-encoded (this is based on the existing behaviour of the Cucumber Reports plugin for Jenkins).