### PR TITLE
fix <p> and <div> order for block 'scenario-container'

### DIFF
--- a/templates/_common/bootstrap.hierarchy/features.tmpl
+++ b/templates/_common/bootstrap.hierarchy/features.tmpl
@@ -77,7 +77,7 @@
                                     <% } %>
                                     <span class="text">
                         <span class="keyword highlight"><%= step.keyword %></span>
-                          <span> <%= step.name %></span>
+                          <span> <%- step.name %></span>
                           <% if (step.result) { %>
                               <span class="step-duration">
                                <%= calculateDuration(step.result.duration) %>
@@ -149,8 +149,8 @@
                                     <% } %>
 
                                     <% } %>
-                                </p>
-                            </div>
+                            	</div>
+                            </p>
                             <% } %>
                             <% }); %>
                         </div>

--- a/templates/foundation/features.tmpl
+++ b/templates/foundation/features.tmpl
@@ -8,7 +8,7 @@
     <% _.each(feature.elements, function(element, scenarioIndex) { %>
       <div class="section-container accordion" data-section="accordion">
         <section>
-          <p class="title accordion-title" data-section-title><a href="#"><spa><%= element.keyword %>: </span><%= element.name %>
+          <p class="title accordion-title" data-section-title><a href="#"><span><%= element.keyword %>: </span><%= element.name %>
           <a>
             <% if(_.some(element.steps, function(step){ return step.result && step.result.status === 'failed'; })) {  %>
               <span class="alert label right">Failed</span>
@@ -28,7 +28,7 @@
             <% _.each(element.steps, function(step, stepIndex) { %>
 
               <p class="subheader">
-                <span class="text"><span class="keyword highlight"><%= step.keyword %></span> <%= step.name %></span>
+                <span class="text"><span class="keyword highlight"><%= step.keyword %></span> <%- step.name %></span>
 		<% if(step.result) { %>
                 <small>
                 <% if(step.result.status === 'failed') { %>

--- a/templates/simple/features.tmpl
+++ b/templates/simple/features.tmpl
@@ -11,7 +11,7 @@
             <% if(step.result) { %>
             <span class="text <%= step.result.status %>">
             <% } %>
-            <span class="keyword highlight"><%= step.keyword %></span> <%= step.name %></span>
+            <span class="keyword highlight"><%= step.keyword %></span> <%- step.name %></span>
              <% if (step.text) { %>
                    <div id="error">
                      <br>


### PR DESCRIPTION
- The `<p>` and `<div>` elements are not nested properly.
- The "step name" shall be escaped to make a well-formed HTML output.