### PR TITLE
Add support for cucumber2 attachments. Backwards compatibility

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -212,13 +212,15 @@ var generateReport = function (options) {
                     if (step.embeddings !== undefined) {
                         step.embeddings.forEach(function (embedding) {
 
-                            if (embedding.media.type === 'text/plain') {
+                            if ((embedding.media && embedding.media.type === 'text/plain') ||
+                                embedding.mime_type === 'text/plain') {
                                 if (!step.text) {
                                     step.text = embedding.data;
                                 } else {
                                     step.text = step.text.concat('<br>' + embedding.data);
                                 }
-                            } else if (embedding.media.type === 'application/json') {
+                            } else if ((embedding.media && embedding.media.type === 'application/json') ||
+                                embedding.mime_type === 'application/json')  {
                                 var decoded = new Buffer(embedding.data, 'base64').toString('ascii');
 
                                 if (!step.text) {
@@ -226,7 +228,8 @@ var generateReport = function (options) {
                                 } else {
                                     step.text = step.text.concat('<br>' + decoded);
                                 }
-                            } else if (embedding.media.type === 'image/png') {
+                            } else if ((embedding.media && embedding.media.type === 'image/png') ||
+                                embedding.mime_type === 'image/png') {
                                 step.image = 'data:image/png;base64,' + embedding.data;
 
                                 if ((options.storeScreenshots && options.storeScreenshots === true) ||


### PR DESCRIPTION
With cucumber2 for js, when trying to create html report from the json one, this module throws an exception because cant find media attribute inside embedding object. It looks for embedding.media.type and it throws an error.

This is because in latest cucumber json report, has moved this attribute to embeddings.mime_type.

With this pull request, this problem is solved, but also works with older json versions.

Best regards.