### PR TITLE
add support to display senario.attach('<html-tag/>', 'text/html')

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -223,9 +223,10 @@ var generateReport = function (options) {
                                 embeddingType = embedding.media.type;
                             }
 
-                            if (embeddingType === 'text/plain') {
+                            if (embeddingType === 'text/plain' || embeddingType === 'text/html') {
+                                var decoded = new Buffer(embedding.data, 'base64').toString('ascii');
                                 if (!step.text) {
-                                    step.text = embedding.data;
+                                    step.text = decoded;
                                 } else {
                                     step.text = step.text.concat('<br>' + embedding.data);
                                 }


### PR DESCRIPTION
Give I have obtained screenshots.png and/or video.mp4 files in a relative path to the cucumber.json file folder
When I use cucumber.attach() function to attach a HTML tag that reference to the file path
And I use cucumber-html-reporter to generate a cucumber.html report
Then I should see the HTML tag displayed property.

attach HTML tag examples:

After: function(scenario) {
    var videoHtmlTag=`'<video src="Passed_Win7_IE11_Validate_Modifications_Performance.mp4" style="max-width: 100%; height: auto;" controls="" poster="Passed_Win7_IE11_Validate_Modifications_Performance.png">Your browser does not support the video tag.</video>'`;
    var screenShotTag=`'<img src="Passed_Win7_IE11_Validate_Modifications_Performance.png">'`;
    if (process.env.MOVIE == 1) {
      scenario.attach(videoHtmlTag, 'html/text');
    } else {
      scenario.attach(screenShotTag, 'html/text);
    }
},
