### PR TITLE
Replace vulnerable open module by opn

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -5,7 +5,7 @@ var _ = require('lodash');
 var fs = require('fs-extra');
 var path = require('path');
 var jsonDir = require('./jsonDir');
-var open = require('open');
+var opn = require('opn');
 var searchFileUp = require('./searchFileUp');
 var hierarchyReporter = require('./hierarchyReporter');
 
@@ -447,7 +447,7 @@ function generate(options, callback) {
 
     function launchReport() {
         if (fs.existsSync(options.output) && (options.launchReport || options.launchReport === 'true')) {
-            open(options.output);
+            opn(options.output);
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,9 @@
       "integrity": "sha512-cjC3jUCh9spkroKue5PDSKH5RFQ/KNuZJhk3GwHYmB/8qqETxLOmMdLH+ohi/VukNzxDlMvIe7zScvLoOdhb6Q==",
       "dev": true,
       "requires": {
-        "diff": "3.4.0",
-        "pad-right": "0.2.2",
-        "repeat-string": "1.6.1"
+        "diff": "^3.0.0",
+        "pad-right": "^0.2.2",
+        "repeat-string": "^1.6.1"
       }
     },
     "babel-runtime": {
@@ -33,8 +33,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.3",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "balanced-match": {
@@ -61,7 +61,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -71,9 +71,9 @@
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.2",
-        "deep-eql": "0.1.3",
-        "type-detect": "1.0.0"
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
       },
       "dependencies": {
         "assertion-error": {
@@ -160,32 +160,32 @@
       "integrity": "sha512-MoUISUsbXWBnq6tuJnq4P3NNaXAe5hltUSnfmeWzly4JnfsqZwJZx8yj99kpzIelqbM/o4MWwbJhEbO/JuXuhg==",
       "dev": true,
       "requires": {
-        "assertion-error-formatter": "2.0.1",
-        "babel-runtime": "6.26.0",
-        "bluebird": "3.5.1",
-        "cli-table": "0.3.1",
-        "colors": "1.1.2",
-        "commander": "2.13.0",
-        "cucumber-expressions": "5.0.13",
-        "cucumber-tag-expressions": "1.1.1",
-        "duration": "0.2.0",
-        "escape-string-regexp": "1.0.5",
+        "assertion-error-formatter": "^2.0.1",
+        "babel-runtime": "^6.11.6",
+        "bluebird": "^3.4.1",
+        "cli-table": "^0.3.1",
+        "colors": "^1.1.2",
+        "commander": "^2.9.0",
+        "cucumber-expressions": "^5.0.7",
+        "cucumber-tag-expressions": "^1.1.1",
+        "duration": "^0.2.0",
+        "escape-string-regexp": "^1.0.5",
         "figures": "2.0.0",
-        "gherkin": "5.0.0",
-        "glob": "7.1.2",
-        "indent-string": "3.2.0",
-        "is-generator": "1.0.3",
-        "is-stream": "1.1.0",
-        "lodash": "4.17.4",
-        "mz": "2.7.0",
-        "progress": "2.0.0",
-        "resolve": "1.5.0",
-        "stack-chain": "2.0.0",
-        "stacktrace-js": "2.0.0",
+        "gherkin": "^5.0.0",
+        "glob": "^7.0.0",
+        "indent-string": "^3.1.0",
+        "is-generator": "^1.0.2",
+        "is-stream": "^1.1.0",
+        "lodash": "^4.17.4",
+        "mz": "^2.4.0",
+        "progress": "^2.0.0",
+        "resolve": "^1.3.3",
+        "stack-chain": "^2.0.0",
+        "stacktrace-js": "^2.0.0",
         "string-argv": "0.0.2",
-        "title-case": "2.1.1",
-        "util-arity": "1.1.0",
-        "verror": "1.10.0"
+        "title-case": "^2.1.1",
+        "util-arity": "^1.0.2",
+        "verror": "^1.9.0"
       }
     },
     "cucumber-expressions": {
@@ -194,7 +194,7 @@
       "integrity": "sha1-8XRZfa5tLwEhKUrC6mVEMknPFYc=",
       "dev": true,
       "requires": {
-        "becke-ch--regex--s0-0-v1--base--pl--lib": "1.2.0"
+        "becke-ch--regex--s0-0-v1--base--pl--lib": "^1.2.0"
       }
     },
     "cucumber-tag-expressions": {
@@ -209,7 +209,7 @@
       "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.38"
+        "es5-ext": "~0.10.2"
       }
     },
     "diff": {
@@ -224,8 +224,8 @@
       "integrity": "sha1-X5xN+q//ZV3phhEu/iXFl43YUUY=",
       "dev": true,
       "requires": {
-        "d": "0.1.1",
-        "es5-ext": "0.10.38"
+        "d": "~0.1.1",
+        "es5-ext": "~0.10.2"
       }
     },
     "error-stack-parser": {
@@ -234,7 +234,7 @@
       "integrity": "sha1-oyArj7AxFKqbQKDjZp5IsrZaAQo=",
       "dev": true,
       "requires": {
-        "stackframe": "1.0.4"
+        "stackframe": "^1.0.3"
       }
     },
     "es5-ext": {
@@ -243,8 +243,8 @@
       "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1"
       }
     },
     "es6-iterator": {
@@ -253,9 +253,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       },
       "dependencies": {
         "d": {
@@ -264,7 +264,7 @@
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true,
           "requires": {
-            "es5-ext": "0.10.38"
+            "es5-ext": "^0.10.9"
           }
         }
       }
@@ -275,8 +275,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.38"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       },
       "dependencies": {
         "d": {
@@ -285,7 +285,7 @@
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true,
           "requires": {
-            "es5-ext": "0.10.38"
+            "es5-ext": "^0.10.9"
           }
         }
       }
@@ -308,7 +308,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "find": {
@@ -316,7 +316,7 @@
       "resolved": "https://registry.npmjs.org/find/-/find-0.2.7.tgz",
       "integrity": "sha1-evvQD48IxbYi+Xzab3FBc9VHuz8=",
       "requires": {
-        "traverse-chain": "0.1.0"
+        "traverse-chain": "~0.1.0"
       },
       "dependencies": {
         "traverse-chain": {
@@ -331,9 +331,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
       "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "3.0.1",
-        "universalify": "0.1.0"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^3.0.0",
+        "universalify": "^0.1.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -366,12 +366,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "indent-string": {
@@ -386,8 +386,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -408,6 +408,11 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+    },
     "js-base64": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
@@ -418,7 +423,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
       "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       },
       "dependencies": {
         "graceful-fs": {
@@ -446,7 +451,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "mz": {
@@ -455,9 +460,9 @@
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dev": true,
       "requires": {
-        "any-promise": "1.3.0",
-        "object-assign": "4.1.1",
-        "thenify-all": "1.6.0"
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
       }
     },
     "no-case": {
@@ -466,7 +471,7 @@
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.1"
       }
     },
     "object-assign": {
@@ -481,13 +486,16 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
-    "open": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
-      "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw="
+    "opn": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+      "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+      "requires": {
+        "is-wsl": "^1.1.0"
+      }
     },
     "pad-right": {
       "version": "0.2.2",
@@ -495,7 +503,7 @@
       "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
       "dev": true,
       "requires": {
-        "repeat-string": "1.6.1"
+        "repeat-string": "^1.5.2"
       }
     },
     "path-is-absolute": {
@@ -534,7 +542,7 @@
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "source-map": {
@@ -555,7 +563,7 @@
       "integrity": "sha512-Qj3X+vY7qQ0OOLQomEihHk5SSnSPCI3z4RfB8kDk9lnzwznBODlkWODitEo8sHpp0a2VdSy3yuJkabNsQN5RGA==",
       "dev": true,
       "requires": {
-        "stackframe": "1.0.4"
+        "stackframe": "^1.0.4"
       }
     },
     "stackframe": {
@@ -571,7 +579,7 @@
       "dev": true,
       "requires": {
         "source-map": "0.5.6",
-        "stackframe": "1.0.4"
+        "stackframe": "^1.0.4"
       }
     },
     "stacktrace-js": {
@@ -580,9 +588,9 @@
       "integrity": "sha1-d2ymRqlbxsayuQd2U2p/xyxt21g=",
       "dev": true,
       "requires": {
-        "error-stack-parser": "2.0.1",
-        "stack-generator": "2.0.2",
-        "stacktrace-gps": "3.0.2"
+        "error-stack-parser": "^2.0.1",
+        "stack-generator": "^2.0.1",
+        "stacktrace-gps": "^3.0.1"
       }
     },
     "string-argv": {
@@ -597,7 +605,7 @@
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "dev": true,
       "requires": {
-        "any-promise": "1.3.0"
+        "any-promise": "^1.0.0"
       }
     },
     "thenify-all": {
@@ -606,7 +614,7 @@
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "dev": true,
       "requires": {
-        "thenify": "3.3.0"
+        "thenify": ">= 3.1.0 < 4"
       }
     },
     "title-case": {
@@ -615,8 +623,8 @@
       "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
       "dev": true,
       "requires": {
-        "no-case": "2.3.2",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.0.3"
       }
     },
     "upper-case": {
@@ -637,9 +645,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.4.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "js-base64": "^2.3.2",
     "jsonfile": "^3.0.0",
     "lodash": "^4.17.2",
-    "open": "0.0.5"
+    "opn": "5.3.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Open module has been declared critically vulnerable by npm security.
This pull request replace it by the maintained version opn.