### PR TITLE
Show step arguments in templates

### DIFF
--- a/templates/_common/bootstrap.hierarchy/features.html
+++ b/templates/_common/bootstrap.hierarchy/features.html
@@ -114,7 +114,7 @@
                         <span class="keyword highlight"><%= step.keyword %></span>
                           <span> <%- step.name %></span>
 
-                          <% if(step.arguments.length) { %>
+                          <% if(step.arguments && step.arguments.length) { %>
                             <% _.each(step.arguments, function(argument) { %>
                               <p class="argument"><pre><%= argument %></pre></p>
                             <% }) %>

--- a/templates/_common/bootstrap.hierarchy/features.html
+++ b/templates/_common/bootstrap.hierarchy/features.html
@@ -113,6 +113,16 @@
                                     <span class="text">
                         <span class="keyword highlight"><%= step.keyword %></span>
                           <span> <%- step.name %></span>
+
+                          <% if(step.arguments.length) { %>
+                            <% _.each(step.arguments, function(argument) { %>
+                              <p class="argument"><pre><%= argument %></pre></p>
+                            <% }) %>
+                          <% } %>
+
+
+
+
                             <% if (step.doc_string && step.doc_string.value) { %>
                               <span>
                                <%- step.doc_string.value %>

--- a/templates/foundation/features.html
+++ b/templates/foundation/features.html
@@ -29,6 +29,15 @@
 
               <p class="subheader">
                 <span class="text"><span class="keyword highlight"><%= step.keyword %></span> <%- step.name %></span>
+
+                <% if(step.arguments.length) { %>
+                  <% _.each(step.arguments, function(argument) { %>
+                    <p class="argument"><pre><%= argument %></pre></p>
+                  <% }) %>
+                <% } %>
+
+
+
 		<% if(step.result) { %>
                 <small>
                 <% if(step.result.status === 'failed') { %>

--- a/templates/foundation/features.html
+++ b/templates/foundation/features.html
@@ -30,7 +30,7 @@
               <p class="subheader">
                 <span class="text"><span class="keyword highlight"><%= step.keyword %></span> <%- step.name %></span>
 
-                <% if(step.arguments.length) { %>
+                <% if(step.arguments && step.arguments.length) { %>
                   <% _.each(step.arguments, function(argument) { %>
                     <p class="argument"><pre><%= argument %></pre></p>
                   <% }) %>

--- a/templates/simple/features.html
+++ b/templates/simple/features.html
@@ -12,6 +12,13 @@
             <span class="text <%= step.result.status %>">
             <% } %>
             <span class="keyword highlight"><%= step.keyword %></span> <%- step.name %></span>
+
+            <% if(step.arguments.length) { %>
+              <% _.each(step.arguments, function(argument) { %>
+                <p class="argument"><pre><%= argument %></pre></p>
+              <% }) %>
+            <% } %>
+
              <% if (step.text) { %>
                    <div class="error">
                      <br>

--- a/templates/simple/features.html
+++ b/templates/simple/features.html
@@ -13,7 +13,7 @@
             <% } %>
             <span class="keyword highlight"><%= step.keyword %></span> <%- step.name %></span>
 
-            <% if(step.arguments.length) { %>
+            <% if(step.arguments && step.arguments.length) { %>
               <% _.each(step.arguments, function(argument) { %>
                 <p class="argument"><pre><%= argument %></pre></p>
               <% }) %>


### PR DESCRIPTION
If you have a definition step in your .feature file like this

```gherkin
    When I send a POST request to "/endpoint" with the body:
    """
    {
      "client_id":      "client id",
      "client_secret":  "secret",
      "grant_type":     "grant",
      "scope":          "scopes"
    }
    """
```

You need to see the argument in the generated report. 

