### PR TITLE
Check if embeddings are base64 encoded (even `text/plain`)

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -9,6 +9,8 @@ var opn = require('opn');
 var searchFileUp = require('./searchFileUp');
 var hierarchyReporter = require('./hierarchyReporter');
 
+const isBase64 = (data) => /^(?:[A-Z0-9+\/]{4})*(?:[A-Z0-9+\/]{2}==|[A-Z0-9+\/]{3}=|[A-Z0-9+\/]{4})$/i.test(data);
+
 var generateReport = function (options) {
 
     var featureOutput = jsonFile.readFileSync(options.jsonFile);
@@ -240,12 +242,12 @@ var generateReport = function (options) {
                                 embeddingType = embedding.media.type;
                             }
 
-                            if (embeddingType === 'text/plain' || embeddingType === 'text/html') {
+                            if (['text/plain', 'text/html', 'application/json'].includes(embeddingType)) {
 
                                 var decoded;
 
-                                if (embeddingType === 'text/html') {
-                                    decoded = new Buffer(embedding.data, 'base64').toString('ascii');
+                                if (isBase64(embedding.data)) {
+                                    decoded = new Buffer(embedding.data, 'base64').toString('utf8');
                                 } else {
                                     decoded = embedding.data;
                                 }
@@ -253,15 +255,7 @@ var generateReport = function (options) {
                                 if (!step.text) {
                                     step.text = decoded;
                                 } else {
-                                    step.text = step.text.concat('<br>' + embedding.data);
-                                }
-                            } else if (embeddingType === 'application/json') {
-                                var decoded = new Buffer(embedding.data, 'base64').toString('ascii');
-
-                                if (!step.text) {
-                                    step.text = decoded;
-                                } else {
-                                    step.text = step.text.concat('<br>' + decoded);
+                                    step.text = step.text.concat(`<br>${decoded}`);
                                 }
                             } else if (embeddingType === 'image/png') {
                                 step.image = 'data:image/png;base64,' + embedding.data;

--- a/templates/_common/bootstrap.hierarchy/features.html
+++ b/templates/_common/bootstrap.hierarchy/features.html
@@ -219,7 +219,7 @@
                                          data-toggle="modal"
                                          style="cursor: pointer"
                                          data-target="#info-modal-<%= featureIndex %>_<%= scenarioIndex %><%= stepIndex %>">
-                                        <pre class="info show-modal"><br><%= step.text %></pre>
+                                        <pre class="info show-modal"><%= step.text %></pre>
                                     </div>
 
                                 <div class="modal fade" id="info-modal-<%= featureIndex %>_<%= scenarioIndex %><%= stepIndex %>" tabindex="-1" role="dialog"
@@ -236,7 +236,7 @@
                                             </div>
                                             <div class="modal-body">
                                                 <h5>
-                                                    <pre><br><%= step.text %></pre>
+                                                    <pre><%= step.text %></pre>
                                                 </h5>
                                             </div>
 


### PR DESCRIPTION
I had some problems with `text/plain` embeddings with jenkins `cucumber-reports-plugin`. After some troubleshooting I found that it assumed that all embeddings where base64 decoded. This was because the java cucumber attachment manager base64 encodes all attachments[0][1]. This is not the case with javascript cucumber.

So when attaching the base64 encoded strings, they would not be shown correctly in the report generated by `cucumber-html-reporter`.

Instead of assuming if certain mime types is base64 encoded or not, this PR adds a simple check to determine if they actually are, and then adds the decoded (as `utf8` instead of `ascii`) data to the report. 

It also fixes a bug where if you would have more than one base64 encoded embedding, it would only add the decoded version of the data to the report for the first embedding.

Lastly, it removes some extraneous line breaks from the template when showing `step.text`.

[0] https://github.com/damianszczepanik/cucumber-reporting/pull/657

[1] https://github.com/cucumber/cucumber-jvm/blob/master/core/src/main/java/cucumber/runtime/formatter/JSONFormatter.java#L344