### PR TITLE
Scenario timestamp and notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ var options = {
         jsonFile: 'test/report/cucumber_report.json',
         output: 'test/report/cucumber_report.html',
         reportSuiteAsScenarios: true,
+        scenarioTimestamp: true,
         launchReport: true,
         metadata: {
             "App Version":"0.3.2",
@@ -208,6 +209,14 @@ Default: `undefined`
 `true`: Applicable if `storeScreenshots=true`. Avoids inlining screenshots, uses relative path to screenshots instead (i.e. enables lazy loading of images).
 
 `false` or `undefined`: Keeps screenshots inlined.
+
+### `scenarioTimestamp`
+Type: `Boolean`
+Default: `undefined`
+
+`true`: Applicable if `theme: 'bootstrap'`. Shows the starting timestamp of each scenario within the title.
+
+`false` or `undefined`: Does not show starting timestamp.
 
 #### `metadata`
 Type: `JSON` (optional)

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -225,6 +225,7 @@ var generateReport = function (options) {
                 element.pending = 0;
                 element.ambiguous = 0;
                 element.time = 0;
+                element.notes = '';
 
                 if (element.type === 'background') {
                     return;
@@ -286,7 +287,11 @@ var generateReport = function (options) {
                     }
 
                     if (step.result.duration) element.time += step.result.duration;
-                    
+
+                    step.output && step.output.forEach(function(o) {
+                        element.notes += o + '<br/>';
+                    });
+
                     switch (step.result.status) {
                       case result.status.passed:
                         return element.passed++;

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -225,13 +225,14 @@ var generateReport = function (options) {
                 element.pending = 0;
                 element.ambiguous = 0;
                 element.time = 0;
+                element.timestamp = '';
                 element.notes = '';
 
                 if (element.type === 'background') {
                     return;
                 }
 
-                element.steps.forEach(function (step) {
+                element.steps.forEach(function (step, count) {
                     if (step.embeddings !== undefined) {
                         step.embeddings.forEach(function (embedding) {
 
@@ -288,9 +289,14 @@ var generateReport = function (options) {
 
                     if (step.result.duration) element.time += step.result.duration;
 
-                    step.output && step.output.forEach(function(o) {
-                        element.notes += o + '<br/>';
-                    });
+                    if (step.output) {
+                        if (options.scenarioTimestamp && count == 0) {
+                            element.timestamp = step.output[0];
+                        }
+                        step.output.forEach(function(o) {
+                            element.notes += o + '<br/>';
+                        });
+                    }
 
                     switch (step.result.status) {
                       case result.status.passed:

--- a/templates/_common/bootstrap.hierarchy/features.html
+++ b/templates/_common/bootstrap.hierarchy/features.html
@@ -80,6 +80,7 @@
                         <div id="collapseScenario<%= suite.name.sanitized %><%= featureIndex %>_<%= scenarioIndex %>"
                              class="panel-collapse collapse">
                             <div class="panel-body">
+                                <div><%= element.notes %></div>
                                 <% if (element.description) { %>
                                 <div class="description" id="scenario-description"><%=
                                     element.description.trim().replace(/\n/g, '<br/>') %>

--- a/templates/_common/bootstrap.hierarchy/features.html
+++ b/templates/_common/bootstrap.hierarchy/features.html
@@ -74,6 +74,7 @@
                             </span>
                                         </div>
                                     </div>
+                                    <div><small><i><%= element.timestamp %></i></small></div>
                                 </a>
                             </h4>
                         </div>


### PR DESCRIPTION
This PR shows additional notes for each scenario, whenever they are available from the `.json` data. From cucumber we have such an information like:
```json
"..."
"type": "scenario",
"steps": [
  {
    "keyword": "When ",
    "name": "I follow the left menu \"Systems > Overview\"",
    "line": 24,
    "output": [
      "This scenario ran at: 2019-08-20 15:38:32 +0200 - 160 seconds since start"
    ],
"..."
  },
"..."
  {
    "keyword": "And ",
    "name": "I should see a Sign Out link",
    "line": 38,
    "match": {
      "location": "features/step_definitions/navigation_steps.rb:740"
    },
    "result": {
      "status": "passed",
      "duration": 19194664
    },
    "output": [
      "This scenario took: 2 seconds"
    ]
  }
"..."
```
Notice the `output` keyword: the first step data contains the timestamp when the scenario started, and the last one contains the time the entire scenario took. These are useful information it would be nice to see inline with the report inside each scenario. Moreover, sometime the `output` field can contain some more information returned from the cucumber run.

---

### Notes inside a scenario
![notes](https://user-images.githubusercontent.com/7080830/63418899-24556400-c404-11e9-9175-57f3ac7dc66e.png)

---

### Timestamp within each scenario title
This is optional and can be enabled only adding the `scenarioTimestamp: true` parameter in the `index.js` options [documented here](https://github.com/gkushang/cucumber-html-reporter/pull/190/commits/7d5f3f19b8e1de12126fec4f6cbf24906ad98923#diff-04c6e90faac2675aa89e2176d2eec7d8R213) and [implemented here](https://github.com/gkushang/cucumber-html-reporter/pull/190/commits/7d5f3f19b8e1de12126fec4f6cbf24906ad98923#diff-7744650016d52918f79696c96d468795R293)
![timestamp](https://user-images.githubusercontent.com/7080830/63418900-24556400-c404-11e9-94e6-d0f53539548b.png)
