### PR TITLE
Fixed regression of 4.0.4, fixes #160

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -293,7 +293,7 @@ var generateReport = function (options) {
                       case result.status.failed:
                         return element.failed++;
                       case result.status.undefined:
-                        return element.undefined++;
+                        return element.notdefined++;
                       case result.status.pending:
                         return element.pending++;
                       case result.status.ambiguous:


### PR DESCRIPTION
I noticed errors in my reports and searched for open issues, found this: https://github.com/gkushang/cucumber-html-reporter/issues/160

It's indeed because of a wrong property name, the typo was introduced here: https://github.com/gkushang/cucumber-html-reporter/commit/c01b76885cc91f378b70ed3b294da53c79842945