### PR TITLE
Merge features from multiple json files in chronological order

### DIFF
--- a/lib/jsonDir.js
+++ b/lib/jsonDir.js
@@ -33,8 +33,8 @@ var collectJSONS = function (options) {
     }
 
     function addTimestamp(featureItem) {
-        var timestamp = featureItem["elements"][0]["steps"][0]["output"][0];
-        if (typeof timestamp !== 'undefined') {
+        if (typeof featureItem["elements"][0]["steps"][0]["output"][0] !== 'undefined') {
+            var timestamp = featureItem["elements"][0]["steps"][0]["output"][0];
             featureItem["timestamp"] = Date.parse(timestamp.match(/[0-9]{4}-.+:[0-9]{2}/g));            
         }
         return featureItem;

--- a/lib/jsonDir.js
+++ b/lib/jsonDir.js
@@ -32,7 +32,20 @@ var collectJSONS = function (options) {
         }
     }
 
+    function addTimestamp(featureItem) {
+        var timestamp = featureItem["elements"][0]["steps"][0]["output"][0];
+        if (typeof timestamp !== 'undefined') {
+            featureItem["timestamp"] = Date.parse(timestamp.match(/[0-9]{4}-.+:[0-9]{2}/g));            
+        }
+        return featureItem;
+    }
+
     files.map(mergeJSONS);
+
+    jsonOutput.map(addTimestamp);
+    jsonOutput.sort(function (feature, nextFeature) {
+        return feature.timestamp - nextFeature.timestamp;
+    });
 
     jsonFile.writeFileSync(options.output + '.json', jsonOutput, {spaces: 2});
 

--- a/lib/jsonDir.js
+++ b/lib/jsonDir.js
@@ -33,9 +33,14 @@ var collectJSONS = function (options) {
     }
 
     function addTimestamp(featureItem) {
-        if (typeof featureItem["elements"][0]["steps"][0]["output"][0] !== 'undefined') {
-            var timestamp = featureItem["elements"][0]["steps"][0]["output"][0];
-            featureItem["timestamp"] = Date.parse(timestamp.match(/[0-9]{4}-.+:[0-9]{2}/g));            
+        if (featureItem["elements"] && featureItem["elements"][0] &&
+            featureItem["elements"][0]["steps"] && featureItem["elements"][0]["steps"][0] &&
+            featureItem["elements"][0]["steps"][0]["output"] && featureItem["elements"][0]["steps"][0]["output"][0]) {
+
+            if (typeof featureItem["elements"][0]["steps"][0]["output"][0] !== 'undefined') {
+                var timestamp = featureItem["elements"][0]["steps"][0]["output"][0];
+                featureItem["timestamp"] = Date.parse(timestamp.match(/[0-9]{4}-.+:[0-9]{2}/g));
+            }
         }
         return featureItem;
     }


### PR DESCRIPTION
This PR adds timestamps at feature level (based on the timestamp of first running scenario inside the feature) and then uses this timestamps to sort features in chronological order for finally generated json file. This is useful in situations, where multiple features from different pipelines are running in parallel, so generated json files don't reflect order of its execution time.

PR resolves #185.