### PR TITLE
Bug fix for issue #163, generate report for cucumber_report_{random_num}.json

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -455,8 +455,9 @@ function generate(options, callback) {
 
     function isValidJsonFile() {
         const fs = require('fs');
-        var dynamicReportJsonFileName = fs.readdirSync(String(options.jsonFile), 'utf-8');
-        options.jsonFile = options.jsonFile + "/" + dynamicReportJsonFileName[0];
+        var jsonFilePath = String(options.jsonFile);
+        var dynamicReportJsonFileName = fs.readdirSync(jsonFilePath, 'utf-8');
+        options.jsonFile = jsonFilePath + "/" + dynamicReportJsonFileName[0];
         options.jsonFile = options.jsonFile || options.output + '.json';
 
         try {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -192,7 +192,6 @@ var generateReport = function (options) {
         var featuresSummary = suite.features.summary;
         var screenshotsDirectory;
         suite.reportAs = 'Features';
-
         if(options.screenshotsDirectory) {
             screenshotsDirectory = options.screenshotsDirectory;
         } else {
@@ -245,9 +244,7 @@ var generateReport = function (options) {
                             } else if (embedding.media) {
                                 embeddingType = embedding.media.type;
                             }
-
                             if (['text/plain', 'text/html', 'application/json'].includes(embeddingType)) {
-
                                 var decoded;
 
                                 if (isBase64(embedding.data)) {
@@ -454,10 +451,21 @@ var generateReport = function (options) {
 function generate(options, callback) {
 
     function isValidJsonFile() {
-        var jsonFilePath = options.jsonFile;
-        var dynamicReportJsonFileName = fs.readdirSync(jsonFilePath, 'utf-8');
-        options.jsonFile = jsonFilePath + "/" + dynamicReportJsonFileName[0];
         options.jsonFile = options.jsonFile || options.output + '.json';
+      
+        function isAFile(filePath) {
+            try {
+                return fs.statSync(filePath).isFile();
+            } catch (err) {
+                return false;
+            }
+        }
+ 
+        if(!isAFile(options.jsonFile)) {
+            var jsonFilePath = options.jsonFile;
+            var dynamicReportJsonFileName = fs.readdirSync(jsonFilePath, 'utf-8');
+            options.jsonFile = jsonFilePath + "/" + dynamicReportJsonFileName[0];
+        } 
 
         try {
             JSON.parse(JSON.stringify(jsonFile.readFileSync(options.jsonFile)));

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -455,8 +455,8 @@ function generate(options, callback) {
 
     function isValidJsonFile() {
         const fs = require('fs');
-        var dynamicReportJsonFileName = fs.readdirSync((string)(options.jsonFile));
-        options.jsonFile = options.jsonFile + "/" + dynamicReportJsonFileName;
+        var dynamicReportJsonFileName = fs.readdirSync(options.jsonFile, 'utf-8');
+        options.jsonFile = options.jsonFile + "/" + dynamicReportJsonFileName[0];
         options.jsonFile = options.jsonFile || options.output + '.json';
 
         try {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -454,8 +454,7 @@ var generateReport = function (options) {
 function generate(options, callback) {
 
     function isValidJsonFile() {
-        const fs = require('fs');
-        var jsonFilePath = String(options.jsonFile);
+        var jsonFilePath = options.jsonFile;
         var dynamicReportJsonFileName = fs.readdirSync(jsonFilePath, 'utf-8');
         options.jsonFile = jsonFilePath + "/" + dynamicReportJsonFileName[0];
         options.jsonFile = options.jsonFile || options.output + '.json';

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -455,7 +455,7 @@ function generate(options, callback) {
 
     function isValidJsonFile() {
         const fs = require('fs');
-        var dynamicReportJsonFileName = fs.readdirSync(options.jsonFile, 'utf-8');
+        var dynamicReportJsonFileName = fs.readdirSync(String(options.jsonFile), 'utf-8');
         options.jsonFile = options.jsonFile + "/" + dynamicReportJsonFileName[0];
         options.jsonFile = options.jsonFile || options.output + '.json';
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -455,8 +455,8 @@ function generate(options, callback) {
 
     function isValidJsonFile() {
         const fs = require('fs');
-        const dynamicReportJsonFileName = fs.readdirSync(options.jsonFile);
-        options.jsonFile = options.jsonFile + "/" + dynamicReportJsonFileName[0];
+        var dynamicReportJsonFileName = fs.readdirSync((string)(options.jsonFile));
+        options.jsonFile = options.jsonFile + "/" + dynamicReportJsonFileName;
         options.jsonFile = options.jsonFile || options.output + '.json';
 
         try {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -454,6 +454,9 @@ var generateReport = function (options) {
 function generate(options, callback) {
 
     function isValidJsonFile() {
+        const fs = require('fs');
+        const dynamicReportJsonFileName = fs.readdirSync(options.jsonFile);
+        options.jsonFile = options.jsonFile + "/" + dynamicReportJsonFileName[0];
         options.jsonFile = options.jsonFile || options.output + '.json';
 
         try {

--- a/test/createHtmlReports.js
+++ b/test/createHtmlReports.js
@@ -12,8 +12,7 @@ var theme = {
 };
 
 var outputDirectory = 'test/report/';
-var jsonFile = 'test/report/cucumber_report.json';
-var jsonDir = 'test/report/multi';
+var jsonPath = path.join(process.cwd(),'test/report/multi');
 
 function removeReports() {
     var files = find.fileSync(/\.html/, outputDirectory);
@@ -24,6 +23,8 @@ function removeReports() {
 
 function getOptions(theme) {
     return {
+        jsonFile: jsonPath,
+        jsonDir: jsonPath,
         name: '@cucumber-html-reporter/*&!@#$%)(~<>`', //this tests for the sanitized hyperlinks on report, otherwise this should be plain text english
         theme: theme,
         output: path.join(outputDirectory, 'cucumber_report_' + theme + '.html'),
@@ -44,14 +45,11 @@ function getOptions(theme) {
 
 function getJsonFileOptions(theme) {
     var options = getOptions(theme);
-    options.jsonFile = jsonFile;
     return options;
 }
 
 function getJsonDirOptions(theme) {
     var options = getOptions(theme);
-    options.jsonDir = jsonDir;
-
     return options;
 }
 

--- a/test/createHtmlReports.js
+++ b/test/createHtmlReports.js
@@ -11,8 +11,9 @@ var theme = {
     simple: 'simple'
 };
 
-var outputDirectory = 'test/report/';
-var jsonPath = path.join(process.cwd(),'test/report/multi');
+var outputDirectory = 'test/report';
+var jsonFile = 'test/report/cucumber_report.json';
+var jsonDir = 'test/report/multi';
 
 function removeReports() {
     var files = find.fileSync(/\.html/, outputDirectory);
@@ -23,8 +24,6 @@ function removeReports() {
 
 function getOptions(theme) {
     return {
-        jsonFile: jsonPath,
-        jsonDir: jsonPath,
         name: '@cucumber-html-reporter/*&!@#$%)(~<>`', //this tests for the sanitized hyperlinks on report, otherwise this should be plain text english
         theme: theme,
         output: path.join(outputDirectory, 'cucumber_report_' + theme + '.html'),
@@ -45,11 +44,13 @@ function getOptions(theme) {
 
 function getJsonFileOptions(theme) {
     var options = getOptions(theme);
+    options.jsonFile = jsonFile;
     return options;
 }
 
 function getJsonDirOptions(theme) {
     var options = getOptions(theme);
+    options.jsonDir = jsonDir;
     return options;
 }
 


### PR DESCRIPTION
When I come to use cucumber-html-report npm package, I got similar errors as the descriptions in the issues #163, #206 
My cucumber related config was as below:
"dependencies": {
    "@types/cucumber": "^6.0.0",
   ...
    "cucumber": "^6.0.5",
    "cucumber-html-reporter": "^5.0.2",
}.
After some debugging into the npm package, I noticed that a file with name cucumber_report_{random_num}.json was dynamically created instead of hardcoded file name cucumber_report.json
The proposed commit solution fixed the problems. I hope this fix solution can be integrated into cucumber-html-report official release and also benefit others.