### PR TITLE
Use inline script instead of relying on external script

### DIFF
--- a/templates/_common/bootstrap.hierarchy/features.html
+++ b/templates/_common/bootstrap.hierarchy/features.html
@@ -247,8 +247,7 @@
 
                                     <% if (step.text) { %>
                                     <a href="#info<%= featureIndex %>_<%= scenarioIndex %><%= stepIndex %>"
-                                       class="toggle"
-                                       data-toggle="collapse" class="show-info">Show Info +</a>
+                                       data-toggle="collapse" class="show-info toggle">Show Info +</a>
                                     <div id="info<%= featureIndex %>_<%= scenarioIndex %><%= stepIndex %>"
                                          class="collapse"
                                          data-toggle="modal"
@@ -288,17 +287,25 @@
                                 <% } %>
 
                                     <% if (step.image) { %>
-                                <a class="toggle" href="javascript: void(0);">Screenshot +</a>
-
-                                <a class="screenshot"
+                                <a href="#ss<%= featureIndex %>_<%= scenarioIndex %><%= stepIndex %>"
+                                    data-toggle="collapse" class="toggle">Screenshot +</a>
+                                <div id="ss<%= featureIndex %>_<%= scenarioIndex %><%= stepIndex %>"
+                                    class="screenshot collapse">
+                                    <pre class="info show-modal"
+                                        data-toggle="modal"
+                                        style="cursor: pointer"
+                                        data-target="#ss-modal-<%= featureIndex %>_<%= scenarioIndex %><%= stepIndex %>">
+                                        
+                                        <img class="screenshot" style="height:100%;width:100%;display:block;"
+                                        id="ss-image-<%= featureIndex %>_<%= scenarioIndex %><%= stepIndex %>" src="<%= step.image %>"/>
+                                </div>
+                                <div class="screenshot collapse"
                                    style="cursor: pointer"
 
                                    data-toggle="modal"
                                    data-target="#ss-modal-<%= featureIndex %>_<%= scenarioIndex %><%= stepIndex %>">
 
-                                    <img class="screenshot" style="height:100%;width:100%;display:none;"
-                                         id="my-images" src="<%= step.image %>"/>
-                                </a>
+                                </div>
 
                                 <div class="modal fade" id="ss-modal-<%= featureIndex %>_<%= scenarioIndex %><%= stepIndex %>" tabindex="-1" role="dialog"
                                      aria-labelledby="stacktraceModalLabel" aria-hidden="true">

--- a/templates/_common/screenshot.js
+++ b/templates/_common/screenshot.js
@@ -1,11 +1,14 @@
-$('a.toggle').on('click', function() {
+$('a.toggle').on('click', function(e) {
+    e.preventDefault();
 
-    if ($(this).text() === 'Screenshot -') {
-        // $(this).text('Screenshot +');
-        $(this).next('a.screenshot').find('img').hide();
-    } else if($(this).text() === 'Screenshot +') {
-        // $(this).text('Screenshot -');
-        $(this).next('a.screenshot').find('img').show();
+    if (!$(this).hasClass('collapse')) {
+        if ($(this).text() === 'Screenshot -') {
+            // $(this).text('Screenshot +');
+            $(this).next('a.screenshot').find('img').hide();
+        } else if($(this).text() === 'Screenshot +') {
+            // $(this).text('Screenshot -');
+            $(this).next('a.screenshot').find('img').show();
+        }
     }
 
     if ($(this).text().includes(' -')) {


### PR DESCRIPTION
I'm having a use case where the report of a cucumber run is being stored in an artifact of our pipeline.

So usually if I have a failing test and I want to debug the tests. I would go to see the report.html.
The html is hosted in jenkins in this case and has a strict CSP: "script-src 'unsafe-eval' *"

So when the `screenshot.js` script is being loaded or is trying to be executed i get the following error:
```
Refused to run the JavaScript URL because it violates the following Content Security Policy directive: "script-src 'unsafe-eval' *". Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-...') is required to enable inline execution.
```
So I end up downloading a zip with all the artifacts, just to look at the screenshot file.

This PR fixes this so the collapsing of the show screenshot not depends on an external resource, and can use the bootstrap function (Which is loaded ok).

In my case we are using the bootstrap theme, and i'm only fixing that template.
