### PR TITLE
Do not reorder if there are no timestamps in the json output

### DIFF
--- a/lib/jsonDir.js
+++ b/lib/jsonDir.js
@@ -48,9 +48,11 @@ var collectJSONS = function (options) {
     files.map(mergeJSONS);
 
     jsonOutput.map(addTimestamp);
-    jsonOutput.sort(function (feature, nextFeature) {
-        return feature.timestamp - nextFeature.timestamp;
-    });
+    if (!jsonOutput.filter(f => !f.timestamp).length)
+        jsonOutput.sort(function (feature, nextFeature) {
+            return feature.timestamp - nextFeature.timestamp;
+        });
+    }
 
     jsonFile.writeFileSync(options.output + '.json', jsonOutput, {spaces: 2});
 

--- a/lib/jsonDir.js
+++ b/lib/jsonDir.js
@@ -48,7 +48,7 @@ var collectJSONS = function (options) {
     files.map(mergeJSONS);
 
     jsonOutput.map(addTimestamp);
-    if (!jsonOutput.filter(f => !f.timestamp).length)
+    if (!jsonOutput.filter(f => !f.timestamp).length) {
         jsonOutput.sort(function (feature, nextFeature) {
             return feature.timestamp - nextFeature.timestamp;
         });


### PR DESCRIPTION
When the json output does not contain timestamps, the sort function messes up the order. To avoid that, if there is no timestamp, the output should not be sorted at all.