### PR TITLE
Fix skipped test counters in hierarchy template

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -386,7 +386,7 @@ var generateReport = function (options) {
                 subSuite ? hierarchyReporter.recursivelyIncrementStat(subSuite, 'ambiguous') : suite.ambiguous++;
             } else if (feature.scenarios.count === feature.scenarios.skipped) {
                 featuresSummary.skipped++;
-                subSuite ? hierarchyReporter.recursivelyIncrementStat(subSuite, 'passed') : suite.passed++;
+                subSuite ? hierarchyReporter.recursivelyIncrementStat(subSuite, 'skipped') : suite.skipped++;
             } else if (feature.scenarios.count === feature.scenarios.notdefined) {
                 featuresSummary.notdefined++;
                 subSuite ? hierarchyReporter.recursivelyIncrementStat(subSuite, 'passed') : suite.passed++;


### PR DESCRIPTION
I found that previous PR (#231) was missing one important change to make the fix work. Sorry for that!

Closes #230.