### PR TITLE
Escape HTML values in step arguments

### DIFF
--- a/templates/_common/bootstrap.hierarchy/features.html
+++ b/templates/_common/bootstrap.hierarchy/features.html
@@ -150,7 +150,7 @@
                                       <% var cells = rows[j]["cells"]; %>
                                       <% for( var k = 0; k < cells.length; k++ ) { %>
                                         <td>
-                                          <%= cells[k] %>
+                                          <%- cells[k] %>
                                         </td>
                                       <% } %>
                                       </tr>


### PR DESCRIPTION
This PR fixes issue where HTML report does not render step argument table when it contains html tags.

Eg: 
```
        When I have a step
            | key      |
            | <test> |
```

Updating the lodash template to escape the html escape delimiter to render such cases.
