### PR TITLE
Add support for Scenario Hooks

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -186,6 +186,23 @@ var generateReport = function (options) {
         }
     };
 
+    var parseScenarioHooks = function(data) {
+        return data.map(step => {
+            const match = step.match && step.match.location ? step.match : {location: 'can not be determined'};
+
+            if(step.embeddings == undefined){
+                return {}
+            }
+
+            return {
+                arguments: step.arguments || [],
+                result: step.result,
+                match,
+                embeddings: step.embeddings || []
+            }
+        })
+    };
+
     var setStats = function (suite) {
         var featureOutput = suite.features;
         var topLevelFeatures = [];
@@ -216,6 +233,19 @@ var generateReport = function (options) {
 
             if (!feature.elements) {
                 return;
+            }
+
+            if (feature.elements) {
+                feature.elements.map(scenario => {
+                    const {before, after} = scenario;
+
+                    if (before) {
+                        scenario.steps = parseScenarioHooks(before).concat(scenario.steps);
+                    }
+                    if (after) {
+                        scenario.steps = scenario.steps.concat(parseScenarioHooks(after));
+                    }
+                })
             }
 
             feature.elements.forEach(function (element) {


### PR DESCRIPTION
I noticed that the reporter has not support for scenario hooks when we use newer cucumber versions, I'm currently using 6.1.0.
So, I would like to port this code from another project https://github.com/wswebcreation/multiple-cucumber-html-reporter/pull/130/files into this project.

Please take a look, see if that makes sense for you. I might need to adapt style or something, anything just tell me. Thank you!

