### PR TITLE
Support long scenario outline names by using ellipsis and hover

### DIFF
--- a/templates/_common/bootstrap.hierarchy/features.html
+++ b/templates/_common/bootstrap.hierarchy/features.html
@@ -61,7 +61,7 @@
                                         <div style="padding-right: <%= decideScenarioTitlePadding(element) %>">
                                             <i class="glyphicon glyphicon-chevron-right"></i>
                                             <i class="glyphicon glyphicon-chevron-down"></i>
-                                            <b><%= element.keyword %>:</b><%= element.name %>
+                                            <b><%= element.keyword %>:</b><div class="ellipsis" data-text="<%= _.escape(element.name) %>"><%= element.name %></div>
                                         </div>
                                         <div>
                             <span class="label-container <% if (element.retried) { %>label-retries<% } %>">

--- a/templates/_common/bootstrap.hierarchy/style.css
+++ b/templates/_common/bootstrap.hierarchy/style.css
@@ -276,3 +276,36 @@ pre {
 .label-retries > span:first-child {
     min-width: 100%;
 }
+
+.ellipsis {
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    transition: all .2s linear;
+    white-space: nowrap;
+    padding:.5rem 1rem;
+}
+.ellipsis:focus, .ellipsis:hover {
+  color:transparent;
+}
+.ellipsis:focus:after,.ellipsis:hover:after{
+    content:attr(data-text);
+    overflow: visible;
+    text-overflow: inherit;
+    background: #fff;
+    position: absolute;
+    left:auto;
+    top:auto;
+    width: auto;
+    max-width: 100%;
+    border: 1px solid #eaebec;
+    padding: 0 .5rem;
+    box-shadow: 0 2px 4px 0 rgba(0,0,0,.28);
+    white-space: normal;
+    word-wrap: break-word;
+    display:block;
+    color:black;
+    margin-top:-1.25rem;
+    z-index: 1;
+  }


### PR DESCRIPTION
Examples Tables with large sets of information can cause an overflow of text beyond the boundary of the report.  This PR addresses the issue by using ellipsis and hover css.

Original
![Screenshot 2023-06-08 at 1 53 19 PM](https://github.com/gkushang/cucumber-html-reporter/assets/11752901/540c92bf-9305-4d2e-a33e-3b98498e4a2a)

With change
![Screenshot 2023-06-08 at 1 53 34 PM](https://github.com/gkushang/cucumber-html-reporter/assets/11752901/641a9afe-fc8e-4ee0-9333-e841357587d9)
