### PR TITLE
change scenario tag filter

### DIFF
--- a/templates/_common/bootstrap.hierarchy/features.html
+++ b/templates/_common/bootstrap.hierarchy/features.html
@@ -48,10 +48,9 @@
                     <div class="panel panel-default">
                         <div class="panel-heading">
                             <h4 class="panel-title">
-                                <% var scenarioTagsOnly = feature.tags ? _.drop(element.tags, feature.tags.length) :
-                                element.tags %>
-                                <% if (element.tags) { %>
-                                <div class="tags"><% _.each(scenarioTagsOnly, function(tag) { %> <span class="tag"> <%= tag.name %></span>
+                                <% var scenarioTagsOnly = _.difference(_.map(element.tags, 'name'), _.map(feature.tags, 'name')) %>
+                                <% if (scenarioTagsOnly) { %>
+                                <div class="tags"><% _.each(scenarioTagsOnly, function(tag) { %> <span class="tag"> <%= tag %></span>
                                     <% }); %>
                                 </div>
                                 <% } %>


### PR DESCRIPTION
Hello, not sure if you might like this PR. 

I am having trouble getting all tags listed correctly for the scenarios, so I change the filter routine for the scenario tags. 

In the current version of cucumber-html-reporter it is assumed, the feature tags are again listed in the scenarios, and addition to that, there are specific demands to the tag order of the scenarios. My change is less demanding.

I'd be happy to see that merged, thus I wouldn't need to work around the way I adjust the feature tags.